### PR TITLE
Added Py3.{5,6} & Django 1.11. Removed Py2.6 & Django <1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,20 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
+  - "3.5"
+  - "3.6"
 env:
-  - DJANGO=1.4
-  - DJANGO=1.5
-  - DJANGO=1.6
-  - DJANGO=1.7
-  - DJANGO=1.8
-  - DJANGO=1.9
-  - DJANGO=1.10
+  - DJANGO=1.8.0
+  - DJANGO=1.9.0
+  - DJANGO=1.10.0
+  - DJANGO=1.11.0
 install:
-  - pip install -q Django==$DJANGO
+  - pip install -q Django~=$DJANGO
 script:
   - DJANGO_SETTINGS_MODULE=tests.settings python setup.py test
 
 matrix:
   exclude:
-    - python: "2.6"
-      env: DJANGO=1.7
-
-    - python: "2.6"
-      env: DJANGO=1.8
-
-    - python: "2.6"
-      env: DJANGO=1.9
-
-    - python: "2.6"
-      env: DJANGO=1.10
+    - python: "2.7"
+      env: DJANGO=2.0.0


### PR DESCRIPTION
The latest Django LTS is 1.11. Its ok to support up to the "LTS -1" (1.8) only.
The next Django LTS is 2.0, and will be Py3k only, so lets start testing with Py3k!